### PR TITLE
Fix ships keys not in alphabetical order

### DIFF
--- a/ships/index.js
+++ b/ships/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   adder: require('./adder').adder,
-  alliance_chieftain: require('./alliance_chieftain').alliance_chieftain,
   alliance_challenger: require('./alliance_challenger').alliance_challenger,
+  alliance_chieftain: require('./alliance_chieftain').alliance_chieftain,
   alliance_crusader: require('./alliance_crusader').alliance_crusader,
   anaconda: require('./anaconda').anaconda,
   asp: require('./asp').asp,


### PR DESCRIPTION
Sending PR mostly so the knowledge of this list not being in order won't annoy me. Technically also closes https://github.com/EDCD/coriolis/issues/476 but the proper fix is here: https://github.com/EDCD/coriolis/pull/477.